### PR TITLE
Add "send random number" menu option

### DIFF
--- a/lib/App/ClusterSSH.pm
+++ b/lib/App/ClusterSSH.pm
@@ -592,6 +592,15 @@ sub send_text_to_all_servers {
     }
 }
 
+sub send_variable_text_to_all_servers($&) {
+    my($self, $code) = @_;
+
+    foreach my $svr ( keys(%servers) ) {
+        $self->send_text( $svr, $code->($svr) )
+            if ( $servers{$svr}{active} == 1 );
+    }
+}
+
 sub send_resizemove($$$$$) {
     my ( $self, $win, $x_pos, $y_pos, $x_siz, $y_siz ) = @_;
 
@@ -1867,6 +1876,14 @@ sub populate_send_menu {
                 $self->send_text_to_all_servers( 'echo ClusterSSH Version: '
                         . $self->config->{macro_version}
                         . $self->config->{macro_newline} );
+            },
+        );
+        $menus{send}->command(
+            -label   => 'Random Number',
+            -command => sub {
+                $self->send_variable_text_to_all_servers(
+                    sub { int(rand(1024)) }
+                ),
             },
         );
     }


### PR DESCRIPTION
Add a new option in the send menu to send a random integer from 0 to
1023 to each host. This can be used to spread load across resources
or delay the activation of commands to spread load across time.

e.g. sleep $(( [random] % 10)) &&
        fetch http://srv-$(( [random] % 5 )).small.server/file
