### PR TITLE
Tmancill/debian tweaks

### DIFF
--- a/bin_PL/clusterssh_bash_completion.dist
+++ b/bin_PL/clusterssh_bash_completion.dist
@@ -8,8 +8,7 @@
 #   /etc/bash_completion.d 
 # and source the /etc/bash_completion script - or just restart bash.
 
-have cssh &&
-_cssh()
+_cssh ()
 {
 	local cur prev options paroptions clusters extra_cluster_file_line clusters_line extra_cluster_file
 
@@ -24,12 +23,12 @@ _cssh()
 	         -s --show-history -t --term-args -T --title \
 	         -u --output-config -v --version'
 
-	# find the extra cluster file line in the .csshrc or, alternatively, /etc/csshrc
-	extra_cluster_file_line="`grep '^[[:space:]]*extra_cluster_file' $HOME/.csshrc 2> /dev/null`"
+	# find the extra cluster file line in the .clusterssh/config or, alternatively, /etc/csshrc
+	extra_cluster_file_line="`grep '^[[:space:]]*extra_cluster_file' $HOME/.clusterssh/config 2> /dev/null`"
 	[ -z "$extra_cluster_file_line" ] && extra_cluster_file_line="`grep '^[[:space:]]*extra_cluster_file' /etc/csshrc 2> /dev/null`"
 
 	# find the clusters line in the .csshrc or, alternatively, /etc/csshrc
-	clusters_line="`grep '^[[:space:]]*clusters' $HOME/.csshrc 2> /dev/null`"
+	clusters_line="`grep '^[[:space:]]*clusters' $HOME/.clusterssh/config 2> /dev/null`"
 	[ -z "$clusters_line" ] && clusters_line="`grep '^[[:space:]]*clusters' /etc/csshrc 2> /dev/null`"
 
 	# extract the location of the extra cluster file
@@ -43,6 +42,7 @@ _cssh()
 		[ -n "$clusters_line" ] && echo "$clusters_line" | cut -f 2- -d '=' | tr "$IFS" "\n" || /bin/true
 		[ -n "$extra_cluster_file" ] && sed -e 's/^\([a-z0-9.-]\+\).*$/\1/i' "$extra_cluster_file" 2> /dev/null || /bin/true
 		sed -e 's/^\([a-z0-9.-]\+\).*$/\1/i' /etc/clusters 2> /dev/null || /bin/true
+		sed -e 's/^\([a-z0-9.-]\+\).*$/\1/i' $HOME/.clusterssh/clusters 2> /dev/null || /bin/true
 	} | sort -u)
 
 	# use options and clusters for tab completion, except there isn't yet
@@ -66,5 +66,5 @@ _cssh()
 	esac
 
 	return 0
-}
-[ "$have" ] && complete -F _cssh cssh crsh ctel
+} &&
+complete -F _cssh cssh crsh ctel

--- a/lib/App/ClusterSSH/L10N.pm
+++ b/lib/App/ClusterSSH/L10N.pm
@@ -33,7 +33,7 @@ NOTE: the default language of this module is English.
 
 =head1 METHODS
 
-See Locale::Maketext - there are curently no extra methods in this module.
+See Locale::Maketext - there are currently no extra methods in this module.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Hi Duncan, this PR includes a couple of patches from the Debian packaging that I think are generally applicable.  One is just a typo/spelling error.

The bash-completion script will now look in ~/.clusterssh/clusters, and I removed the "have" logic test because it was preventing the bash completion from working at all for me.