### PR TITLE
added support for specifying the desired number of columns or rows

### DIFF
--- a/lib/App/ClusterSSH.pm
+++ b/lib/App/ClusterSSH.pm
@@ -989,10 +989,11 @@ sub retile_hosts {
     }
     $self->debug( 2, "Screen Columns: ", $self->config->{internal_columns} );
     $self->debug( 2, "Screen Rows: ",    $self->config->{internal_rows} );
+    $self->debug( 2, "Fill scree: ",     $self->config->{fillscreen} );
 
     # Now adjust the height of the terminal to either the max given,
     # or to get everything on screen
-    {
+    if ( $self->config->{fillscreen} ne 'yes' ) {
         my $height = int(
             (   (         $self->config->{internal_screen_height}
                         - $self->config->{screen_reserve_top}
@@ -1005,15 +1006,41 @@ sub retile_hosts {
                 )
             ) / $self->config->{internal_rows}
         );
-
-        $self->debug( 2, "Terminal height=$height" );
-
         $self->config->{internal_terminal_height} = (
               $height > $self->config->{internal_terminal_height}
             ? $self->config->{internal_terminal_height}
             : $height
         );
     }
+    else {
+        $self->config->{internal_terminal_height} = int(
+            (   (         $self->config->{internal_screen_height}
+                        - $self->config->{screen_reserve_top}
+                        - $self->config->{screen_reserve_bottom}
+                ) - (
+                    $self->config->{internal_rows} * (
+                              $self->config->{terminal_reserve_top}
+                            + $self->config->{terminal_reserve_bottom}
+                    )
+                )
+            ) / $self->config->{internal_rows}
+        );
+        $self->config->{internal_terminal_width} = int(
+            (   (         $self->config->{internal_screen_width}
+                        - $self->config->{screen_reserve_left}
+                        - $self->config->{screen_reserve_right}
+                ) - (
+                    $self->config->{internal_columns} * (
+                              $self->config->{terminal_reserve_left}
+                            + $self->config->{terminal_reserve_right}
+                    )
+                )
+            ) / $self->config->{internal_columns}
+        );
+    }
+    $self->debug( 2, "Terminal h: ",
+        $self->config->{internal_terminal_height},
+        ", w: ", $self->config->{internal_terminal_width} );
 
     $self->config->dump("noexit") if ( $self->options->debug_level > 1 );
 
@@ -2409,3 +2436,4 @@ See http://dev.perl.org/licenses/ for more information.
 =cut
 
 1;
+

--- a/lib/App/ClusterSSH.pm
+++ b/lib/App/ClusterSSH.pm
@@ -950,24 +950,43 @@ sub retile_hosts {
     $self->config->{internal_screen_width}  = $xdisplay->{width_in_pixels};
 
     # Now, work out how many columns of terminals we can fit on screen
-    $self->config->{internal_columns} = int(
-        (         $self->config->{internal_screen_width}
-                - $self->config->{screen_reserve_left}
-                - $self->config->{screen_reserve_right}
-        ) / (
-            $self->config->{internal_terminal_width}
-                + $self->config->{terminal_reserve_left}
-                + $self->config->{terminal_reserve_right}
-        )
-    );
+    if ( $self->config->{rows} != -1 || $self->config->{cols} != -1 ) {
+        if ( $self->config->{rows} != -1 ) {
+            $self->config->{internal_rows}    = $self->config->{rows};
+            $self->config->{internal_columns} = int(
+                (         $self->config->{internal_total}
+                        / $self->config->{internal_rows}
+                ) + 0.999
+            );
+        }
+        else {
+            $self->config->{internal_columns} = $self->config->{cols};
+            $self->config->{internal_rows}    = int(
+                (         $self->config->{internal_total}
+                        / $self->config->{internal_columns}
+                ) + 0.999
+            );
+        }
+    }
+    else {
+        $self->config->{internal_columns} = int(
+            (         $self->config->{internal_screen_width}
+                    - $self->config->{screen_reserve_left}
+                    - $self->config->{screen_reserve_right}
+            ) / (
+                $self->config->{internal_terminal_width}
+                    + $self->config->{terminal_reserve_left}
+                    + $self->config->{terminal_reserve_right}
+            )
+        );
 
-    # Work out the number of rows we need to use to fit everything on screen
-    $self->config->{internal_rows} = int(
-        (         $self->config->{internal_total}
-                / $self->config->{internal_columns}
-        ) + 0.999
-    );
-
+      # Work out the number of rows we need to use to fit everything on screen
+        $self->config->{internal_rows} = int(
+            (         $self->config->{internal_total}
+                    / $self->config->{internal_columns}
+            ) + 0.999
+        );
+    }
     $self->debug( 2, "Screen Columns: ", $self->config->{internal_columns} );
     $self->debug( 2, "Screen Rows: ",    $self->config->{internal_rows} );
 

--- a/lib/App/ClusterSSH/Config.pm
+++ b/lib/App/ClusterSSH/Config.pm
@@ -108,6 +108,8 @@ my %default_config = (
 
     # don't set username here as takes precendence over ssh config
     user => '',
+    rows => -1,
+    cols => -1,
 );
 
 sub new {

--- a/lib/App/ClusterSSH/Config.pm
+++ b/lib/App/ClusterSSH/Config.pm
@@ -110,6 +110,9 @@ my %default_config = (
     user => '',
     rows => -1,
     cols => -1,
+
+    fillscreen => "no",
+
 );
 
 sub new {

--- a/lib/App/ClusterSSH/Getopt.pm
+++ b/lib/App/ClusterSSH/Getopt.pm
@@ -250,6 +250,13 @@ sub add_common_options {
         arg_desc => 'rows',
         help     => $self->loc('Number of rows'),
     );
+
+    $self->add_option(
+        spec => 'fillscreen',
+        help => $self->loc(
+            'Resize terminal windows to fill the whole available screen'),
+    );
+
     return $self;
 }
 
@@ -395,6 +402,8 @@ sub getopts {
     if ( $self->cols ) {
         $self->parent->config->{cols} = $self->cols;
     }
+    $self->parent->config->{fillscreen} = "yes"
+        if ( $self->fillscreen );
     return $self;
 }
 

--- a/lib/App/ClusterSSH/Getopt.pm
+++ b/lib/App/ClusterSSH/Getopt.pm
@@ -240,7 +240,16 @@ sub add_common_options {
         help =>
             $self->loc('Do not output extra text when using some options'),
     );
-
+    $self->add_option(
+        spec     => 'cols|x=i',
+        arg_desc => 'cols',
+        help     => $self->loc('Number of columns'),
+    );
+    $self->add_option(
+        spec     => 'rows|y=i',
+        arg_desc => 'rows',
+        help     => $self->loc('Number of rows'),
+    );
     return $self;
 }
 
@@ -380,6 +389,12 @@ sub getopts {
             = !$self->parent->config->{window_tiling} || 0;
     }
 
+    if ( $self->rows ) {
+        $self->parent->config->{rows} = $self->rows;
+    }
+    if ( $self->cols ) {
+        $self->parent->config->{cols} = $self->cols;
+    }
     return $self;
 }
 

--- a/t/15config.t
+++ b/t/15config.t
@@ -126,6 +126,8 @@ Readonly::Hash my %default_config => {
     user => '',
     rows => -1,
     cols => -1,
+
+    fillscreen => 'no',
 };
 my %expected = %default_config;
 is_deeply( $config, \%expected, 'default config is correct' );
@@ -547,6 +549,7 @@ console_position=
 external_cluster_command=
 extra_cluster_file=
 extra_tag_file=
+fillscreen=no
 hide_menu=0
 history_height=10
 history_width=40

--- a/t/15config.t
+++ b/t/15config.t
@@ -124,6 +124,8 @@ Readonly::Hash my %default_config => {
     # other bits inheritted from App::ClusterSSH::Base
     lang => 'en',
     user => '',
+    rows => -1,
+    cols => -1,
 };
 my %expected = %default_config;
 is_deeply( $config, \%expected, 'default config is correct' );
@@ -538,6 +540,7 @@ my $expected = qq{# Configuration dump produced by "cssh -d"
 auto_close=5
 auto_quit=yes
 auto_wm_decoration_offsets=no
+cols=-1
 console=console
 console_args=
 console_position=
@@ -568,6 +571,7 @@ max_host_menu_items=30
 menu_host_autotearoff=0
 menu_send_autotearoff=0
 mouse_paste=Button-2
+rows=-1
 rsh=rsh
 rsh_args=
 screen_reserve_bottom=60


### PR DESCRIPTION
cssh does it's best to distribute the windows, but I wanted to make it obey my will and distribute them how I want it.

**Use case:** 
I have a cluster with 8 nodes, normal invocation puts the windows int a 3 by 3 "matrix", I find it more pleasing to go with a 2x4. with this patch/modification I can just invoke it like 
`cssh -x 2 my_cluster`

_Side note:_
it's even better with the next feature I'll add, expand the windows so that it will take the whole screen (no overlapping).  