### PR TITLE
Do not make files world writable

### DIFF
--- a/bin_PL/_build_docs
+++ b/bin_PL/_build_docs
@@ -24,7 +24,7 @@ for my $dest (@ARGV) {
     print "Generating: $source",$/;
 
     if(-f $dest) {
-        chmod(0777, $dest) || die "Could not chmod $dest for removing: $!";
+        chmod(0755, $dest) || die "Could not chmod $dest for removing: $!";
     }
 
     open(my $sfh, '<', $source) || die "Could not open $source for reading: $!";


### PR DESCRIPTION
If we can chmod it, we own the file,
so we only need a writable-bit for the owner, not for everybody.

The permissions are changed back soon after, but it creates a small window
for local attackers to insert their stuff into our build results.
That makes this a small but easily avoidable security issue.