### PR TITLE
helper: Fix missing space separator for ssh_args

### DIFF
--- a/lib/App/ClusterSSH/Helper.pm
+++ b/lib/App/ClusterSSH/Helper.pm
@@ -71,9 +71,9 @@ sub script {
            my \$user=shift;
            my \$port=shift;
            my \$mstr=shift;
-           my \$command="$command_pre $comms $comms_args";
+           my \$command="$command_pre $comms $comms_args ";
            open(PIPE, ">", \$pipe) or die("Failed to open pipe: \$!\\n");
-           print PIPE "\$\$:\$ENV{WINDOWID}" 
+           print PIPE "\$\$:\$ENV{WINDOWID}"
                or die("Failed to write to pipe: $!\\n");
            close(PIPE) or die("Failed to close pipe: $!\\n");
            if(\$svr =~ m/==\$/)


### PR DESCRIPTION
Docs suggest using ssh_args without space at the end
ssh_args = "-x -o ConnectTimeout=10"

Fixes: 82f8845 ("Add in 'command_pre' and 'command_post' configs")

Signed-off-by: Petr Vorel <petr.vorel@gmail.com>