### PR TITLE
warn user when short-circuiting initialisation

### DIFF
--- a/lib/App/ClusterSSH/Window.pm
+++ b/lib/App/ClusterSSH/Window.pm
@@ -29,7 +29,10 @@ sub import {
 
     # If we are building or in test here, just exit
     # as travis build servers will not have Tk installed
-    return if $ENV{AUTHOR_TESTING} || $ENV{RELEASE_TESTING};
+    if ($ENV{AUTHOR_TESTING} || $ENV{RELEASE_TESTING}) {
+        print STDERR "skipping initialisation; AUTHOR_TESTING or RELEASE_TESTING are set\n";
+        return;
+    }
 
     # Find what windows module we should be using and just overlay it into
     # this object


### PR DESCRIPTION
The intention is to give the user some indication as to why ClusterSSH fails to start when either `AUTHOR_TESTING` or `RELEASE_TESTING` are present in the environment.

See the Debian bug report for [Debian-Bug 989679](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=989679) for a brief discussion.

The bug submitter suggests using a mechanism like the following to
prevent test failures when Tk isn't present:
  https://github.com/dod38fr/config-model-tk-ui/blob/5cf873739ea40771bd39226c7cbfc23b0fdc2ff4/t/config-model-ui.t#L96