### PR TITLE
Don't try to open a directory as the config file

### DIFF
--- a/lib/App/ClusterSSH/Config.pm
+++ b/lib/App/ClusterSSH/Config.pm
@@ -314,7 +314,7 @@ sub load_configs {
         $ENV{HOME} . '/.clusterssh/config',
         )
     {
-        $self->parse_config_file($config) if ( -e $config );
+        $self->parse_config_file($config) if ( -e $config && ! -d _ );
     }
 
     # write out default config file if necesasry
@@ -329,10 +329,10 @@ sub load_configs {
     # relative to config directory
     for my $config (@configs) {
         next unless ($config);    # can be null when passed from Getopt::Long
-        $self->parse_config_file($config) if ( -e $config );
+        $self->parse_config_file($config) if ( -e $config && ! -d _ );
 
         my $file = $ENV{HOME} . '/.clusterssh/config_' . $config;
-        $self->parse_config_file($file) if ( -e $file );
+        $self->parse_config_file($file) if ( -e $file && ! -d _ );
     }
 
     return $self;

--- a/t/15config.t
+++ b/t/15config.t
@@ -535,7 +535,7 @@ SKIP: {
     chmod( 0755, $ENV{HOME} . '/.csshrc.DISABLED', $ENV{HOME} );
 }
 
-note('check failure to write default config is caught');
+note('check failure to write default config is caught when loading config');
 $ENV{HOME} = tempdir( CLEANUP => 1 );
 mkdir( $ENV{HOME} . '/.clusterssh' );
 mkdir( $ENV{HOME} . '/.clusterssh/config' );


### PR DESCRIPTION
This  PR patches `load_configs()` to check that the $config being opened is actually (well, likely) a file and not a directory, which was tripping up the tests that assert that there is an error when the config file cannot be written because a directory already exists.

Until recently, the attempt to read the directory as a file was being silently ignored due to a latent bug in Perl; more about that in [Debian bug report 10163690](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1016369) and [Perl 5 issue 20103](https://github.com/Perl/perl5/pull/20103)

This addresses a bug filed against the Debian package for clusterssh when `t/15config.t` tests started failing after the Perl bug was fixed:  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1026735

The `-e $config && ! -d _` file test operators are used instead of `-e $config && -f _` because it will still support users who might want to symlink their `config` file.