### PR TITLE
Don't check config is a HASH

### DIFF
--- a/lib/App/ClusterSSH/Base.pm
+++ b/lib/App/ClusterSSH/Base.pm
@@ -306,9 +306,7 @@ sub sort {
 
     my $sort = sub { sort @_ };
 
-    return $sort
-        unless ref( $self->config() ) eq "HASH"
-        && $self->config()->{'use_natural_sort'};
+    return $sort unless $self->config()->{'use_natural_sort'};
 
     # if the user has asked for natural sorting we need to include an extra
     # module


### PR DESCRIPTION
At some point `$self->config()` started returning a `bless`ed object so checking it was a `HASH` began to fail, preventing someone using natural sort. AFAIK the config option always has to behave as a hash so it should be safe to avoid this test.